### PR TITLE
CMD line Utils for Tx Port Monitoring Feature

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2846,8 +2846,7 @@ def clear(ctx, interface_name):
 @click.argument('period', metavar='<period>', required=True, type=int)
 def tx_error_stat_poll_period(period):
     """Polling period for Tx error statistics, Enter 0 to disable, xxx for default
-    
-       After Resetting Polling period """
+       After Every Diable, any state information related to this feature is cleared out."""
     config_db = ConfigDBConnector()
     config_db.connect()
     config_db.set_entry("TX_ERR_CFG", ("GLOBAL_PERIOD"), {"tx_error_check_period": period})

--- a/config/main.py
+++ b/config/main.py
@@ -2774,6 +2774,83 @@ def asymmetric(ctx, interface_name, status):
     run_command("pfc config asymmetric {0} {1}".format(status, interface_name))
 
 #
+# 'tx_error_threshold' subgroup (config interface tx_error_threshold ...)
+#
+
+@interface.group()
+@click.pass_context
+def tx_error_threshold(ctx):
+    """Set or Remove threshold of tx error count"""
+    pass
+
+#
+# 'tx_error_threshold' subgroup - set command (config interface tx_error_threshold set <ifname> <count>)
+#
+@tx_error_threshold.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_tx_err_threshold', metavar='<interface_tx_err_threshold>', required=True, type=int)
+def set(ctx, interface_name, interface_tx_err_threshold):
+    """Set threshold of for Tx error count"""
+    if interface_name is None:
+        ctx.fail("'interface_name' is None!")
+
+    config_db = ctx.obj['config_db']
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+    
+    if interface_name.startswith("Ethernet"):
+        config_db.set_entry("TX_ERR_CFG", (interface_name), {"tx_error_threshold": interface_tx_err_threshold})
+    else:
+        ctx.fail("Only Ethernet interfaces are supported")    
+
+
+#
+# 'tx_error_threshold' subgroup - clear command (config interface tx_error_threshold clear <ifname>)
+#
+@tx_error_threshold.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+def clear(ctx, interface_name):
+    """Clear threshold for Tx Error Monitoring"""
+    if interface_name is None:
+        ctx.fail("'interface_name' is None!")
+
+    config_db = ctx.obj["config_db"]
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    if config_db.get_entry('TX_ERR_CFG', interface_name):
+        if interface_name.startswith("Ethernet"):
+            config_db.set_entry("TX_ERR_CFG", (interface_name), None)
+        else:
+            ctx.fail("Only Ethernet interfaces are supported")
+    else:
+        ctx.fail("Tx Error threshold hasn't been configured on the interface")
+
+
+#
+# 'tx_error_stat_poll_period' subcommand config tx_error_stat_poll_period <period in sec>'
+#
+@config.command()
+@click.argument('period', metavar='<period>', required=True, type=int)
+def tx_error_stat_poll_period(period):
+    """Polling period for Tx error statistics, Enter 0 to disable, xxx for default"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.set_entry("TX_ERR_CFG", ("GLOBAL_PERIOD"), {"tx_error_check_period": period})
+
+#
 # 'platform' group ('config platform ...')
 #
 

--- a/config/main.py
+++ b/config/main.py
@@ -2794,14 +2794,14 @@ def set(ctx, interface_name, interface_tx_err_threshold):
     """Set threshold of for Tx error count"""
     if interface_name is None:
         ctx.fail("'interface_name' is None!")
-
+        
     config_db = ctx.obj['config_db']
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name_is_valid(interface_name) is False:
+    if interface_name_is_valid(config_db, interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
     
     if interface_name.startswith("Ethernet"):
@@ -2827,7 +2827,7 @@ def clear(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name_is_valid(interface_name) is False:
+    if interface_name_is_valid(config_db, interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     if config_db.get_entry('TX_ERR_CFG', interface_name):
@@ -2845,7 +2845,9 @@ def clear(ctx, interface_name):
 @config.command()
 @click.argument('period', metavar='<period>', required=True, type=int)
 def tx_error_stat_poll_period(period):
-    """Polling period for Tx error statistics, Enter 0 to disable, xxx for default"""
+    """Polling period for Tx error statistics, Enter 0 to disable, xxx for default
+    
+       After Resetting Polling period """
     config_db = ConfigDBConnector()
     config_db.connect()
     config_db.set_entry("TX_ERR_CFG", ("GLOBAL_PERIOD"), {"tx_error_check_period": period})

--- a/show/main.py
+++ b/show/main.py
@@ -899,6 +899,62 @@ def portchannel(namespace,  display, verbose):
     
     run_command(cmd, display_cmd=verbose)
 
+# 'txerror' subcommand ("show interfaces txerror")
+@interfaces.command()
+@click.argument('interfacename', required=False)
+def txerror(interfacename):
+    """Show Interface TxError Information """
+    
+    db = SonicV2Connector(host='127.0.0.1')
+    db.connect(db.STATE_DB, False)   # Make one attempt only
+    
+    
+    TABLE_NAME_SEPARATOR = '|'
+    prefix_statedb = "TX_ERR_STATE|"
+    
+    _hash = '{}{}'.format(prefix_statedb, '*')
+    txerr_keys = db.keys(db.STATE_DB, _hash)
+    
+    table = []
+    
+    header = ['Port', 'Status', 'sai_port_id', 'Last Updated On', 'Tx Error Threshold']
+    
+    if txerr_keys is None:
+        txerr_keys = dict()
+        
+    for k in txerr_keys:
+        k = k.replace(prefix_statedb, "") 
+        r = []
+        r.append(k)
+        
+        entry = db.get_all(db.STATE_DB, prefix_statedb + k)
+        
+        if 'tx_error_stats' not in entry:
+            r.append("UnKnown")
+        else:
+            r.append(entry['tx_error_stats'])
+        
+        if 'tx_error_portid' not in entry:
+            r.append("")
+        else:
+            r.append(entry['tx_error_portid'])
+        
+        if 'tx_error_verified_latest_by' not in entry:
+            r.append("")
+        else:
+            r.append(entry['tx_error_verified_latest_by'])
+	
+	if 'tx_error_threshold' not in entry:
+            r.append("")
+        else:
+            r.append(entry['tx_error_threshold'])
+        
+        table.append(r)
+    
+    click.echo(tabulate(table, header))
+        
+    
+    
 #
 # 'subinterfaces' group ("show subinterfaces ...")
 #


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added CMD line Utilities for Tx Port Monitoring Feature.
Related PR's:
sonic-swss:  https://github.com/vivekreddynv/sonic-swss/pull/1
sonic-swss-common https://github.com/vivekreddynv/sonic-swss-common/pull/1

#### How I did it

* Added tx_error_threshold subgroup under config.interface (Specific to interface)
* Added tx_error_stat_poll_period under config (Global across interfaces)
* Added txerror under show.interface 

#### How to verify it

Using redis-cli & Counter DB

```

admin@device:~$ show interface txerror
Port       Status    sai_port_id          Last Updated On        Tx Error Threshold
---------  --------  -------------------  -------------------  --------------------
Ethernet8  OK        oid:0x10000000004c5  2021-03-01.14:45:19                    20
Ethernet0  OK        oid:0x10000000004a4  2021-03-01.14:45:19                    30


admin@device:~$ redis-cli -n 2
127.0.0.1:6379[2]> hget "COUNTERS:oid:0x10000000004c5" SAI_PORT_STAT_IF_OUT_ERRORS
"0"

127.0.0.1:6379[2]> hset "COUNTERS:oid:0x10000000004c5" SAI_PORT_STAT_IF_OUT_ERRORS "25"
(integer) 0
127.0.0.1:6379[2]> hget "COUNTERS:oid:0x10000000004c5" SAI_PORT_STAT_IF_OUT_ERRORS
"25"

admin@device:~$ show interface txerror
Port       Status    sai_port_id          Last Updated On        Tx Error Threshold
---------  --------  -------------------  -------------------  --------------------
Ethernet8  ERROR     oid:0x10000000004c5  2021-03-01.14:46:04                    20
Ethernet0  OK        oid:0x10000000004a4  2021-03-01.14:46:04                    30
```

#### Previous command output (if the output of a command-line utility has changed)
None

#### New command output (if the output of a command-line utility has changed)

```
CMD: 1
admin@device:~$ sudo config tx_error_stat_poll_period --help
Usage: config tx_error_stat_poll_period [OPTIONS] <period>

  Polling period for Tx error statistics, Enter 0 to disable, xxx for
  default After Every Diable, any state information related to this feature
  is cleared out.

Options:
  -?, -h, --help  Show this message and exit.

CMD: 2
admin@device:~$ sudo config interface tx_error_threshold --help
Usage: config interface tx_error_threshold [OPTIONS] COMMAND [ARGS]...

  Set or Remove threshold of tx error count

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  clear  Clear threshold for Tx Error Monitoring
  set    Set threshold of for Tx error count

CMD: 3
admin@device:~$ sudo config interface tx_error_threshold set --help
Usage: config interface tx_error_threshold set [OPTIONS] <interface_name>
                                               <interface_tx_err_threshold>

  Set threshold of for Tx error count

Options:
  -?, -h, --help  Show this message and exit.

CMD: 4
sudo config interface tx_error_threshold set Ethernet16 1000

CMD: 5
admin@device:~$ show interface txerror
Port        Status    sai_port_id          Last Updated On        Tx Error Threshold
----------  --------  -------------------  -------------------  --------------------
Ethernet16  OK        oid:0x1000000000462  2021-03-01.14:46:53                  1000
Ethernet8   ERROR     oid:0x10000000004c5  2021-03-01.14:46:04                    20
Ethernet0   OK        oid:0x10000000004a4  2021-03-01.14:46:49                    30



```