### PR TITLE
[debug dump util] generate_dump script update for debug dump utility

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1011,7 +1011,8 @@ save_counter_snapshot() {
 save_dump_state_all_ns() {
     MODULES="$(dump state -s | sed '1d;2d' | awk '{print $1}')"
     local UVDUMP="unified_view_dump"
-    echo "Modules Available to Generate Debug Dump Output"
+    echo "DEBUG DUMP: Modules Available to Generate Debug Dump Output"
+    echo $MODULES
     $MKDIR $V -p $LOGDIR/$UVDUMP
 
     for addr in $MODULES;

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1006,6 +1006,31 @@ save_counter_snapshot() {
 }
 
 ###############################################################################
+# save the debug dump output
+###############################################################################
+save_dump_state_all_ns() {
+    IFS=';'
+    read -ra MODULES <<< "$(dump state -a)"
+    local UVDUMP="unified_view_dump"
+
+    $MKDIR $V -p $LOGDIR/$UVDUMP
+
+    for addr in "${MODULES[@]}";
+    do
+            save_cmd_all_ns "dump state $addr all --key-map" "$UVDUMP/$addr"
+            if [[ ( "$NUM_ASICS" > 1 ) ]] ; then
+                for (( i=0; i<$NUM_ASICS; i++ ))
+                do
+                        local cmd="dump state $addr all --key-map --namespace asic$i"
+                        local file="$UVDUMP/$addr.$i"
+                        save_cmd "$cmd" "$file"
+                done
+            fi
+    done
+}
+
+
+###############################################################################
 # Main generate_dump routine
 # Globals:
 #  All of them.
@@ -1116,7 +1141,8 @@ main() {
     save_nat_info
     save_bfd_info
     save_redis_info
-
+    save_dump_state_all_ns
+    
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1017,7 +1017,7 @@ save_dump_state_all_ns() {
 
     for addr in $MODULES;
     do
-            save_cmd_all_ns "dump state $addr all --key-map" "$UVDUMP/$addr"
+            save_cmd "dump state $addr all --key-map" "$UVDUMP/$addr"
             if [[ ( "$NUM_ASICS" > 1 ) ]] ; then
                 for (( i=0; i<$NUM_ASICS; i++ ))
                 do

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1009,20 +1009,19 @@ save_counter_snapshot() {
 # save the debug dump output
 ###############################################################################
 save_dump_state_all_ns() {
-    IFS=';'
-    read -ra MODULES <<< "$(dump state -a)"
+    MODULES="$(dump state -s | sed '1d;2d' | awk '{print $1}')"
     local UVDUMP="unified_view_dump"
-
+    echo "Modules Available to Generate Debug Dump Output"
     $MKDIR $V -p $LOGDIR/$UVDUMP
 
-    for addr in "${MODULES[@]}";
+    for addr in $MODULES;
     do
             save_cmd_all_ns "dump state $addr all --key-map" "$UVDUMP/$addr"
             if [[ ( "$NUM_ASICS" > 1 ) ]] ; then
                 for (( i=0; i<$NUM_ASICS; i++ ))
                 do
                         local cmd="dump state $addr all --key-map --namespace asic$i"
-                        local file="$UVDUMP/$addr.$i"
+                        local file="$UVDUMP/$addr.asic$i"
                         save_cmd "$cmd" "$file"
                 done
             fi


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added the logic to extract to `dump state`  of all the available modules 

#### How I did it

Module Names are retrieved by parsing the output of dump state --show command.

Eg: 
```
root@sonic:~# dump state  --help
Usage: dump state [OPTIONS] MODULE IDENTIFIER

  Dump the redis-state of the identifier for the module specified

Options:
............
 -s, --show            Display Modules Available
............

root@sonic:~$ dump state --show
Module    Identifier
--------  ------------
copp      trap_id
port      port_name
```

#### How to verify it

```
root@sonic-dev:~# show techsupport
root@sonic-dev:~# tar -xvzf /var/dump/sonic_dump_sonic-dev-69_20210525_055031.tar.gz
root@sonic-dev:~/sonic_dump_sonic-dev-69_20210525_055031# ls -l dump/ | grep unified_view
drwxr-xr-x 2 root root    4096 May 25 06:05 unified_view_dump
root@sonic-dev:~/sonic_dump_sonic-dev-69_20210525_055031# cd dump/unified_view_dump/
root@sonic-dev:~/sonic_dump_sonic-dev-69_20210525_055031/dump/unified_view_dump# ls
copp  port
root@sonic-dev:~/sonic_dump_sonic-dev-69_20210525_055031/dump/unified_view_dump# cat port

"Ethernet192": {
        "CONFIG_DB": {
            "keys": [
                "PORT|Ethernet192"
            ],
            "tables_not_found": []
        },
        "APPL_DB": {
            "keys": [
                "PORT_TABLE:Ethernet192"
            ],
            "tables_not_found": []
        },
        "ASIC_DB": {
            "keys": [
                "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd000000000585",
                "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000002f7"
            ],
            "tables_not_found": [],
            "vidtorid": {
                "oid:0xd000000000585": "oid:0x180000000d",
                "oid:0x10000000002f7": "oid:0x1350000000001"
            }
        },
        "STATE_DB": {
            "keys": [
                "PORT_TABLE|Ethernet192"
            ],
            "tables_not_found": []
        }
    },
    "Ethernet64": {
        "CONFIG_DB": {
            "keys": [
                "PORT|Ethernet64"
            ],
            "tables_not_found": []
        },
        "APPL_DB": {
            "keys": [
                "PORT_TABLE:Ethernet64"
            ],
            "tables_not_found": []
        },
        "ASIC_DB": {
            "keys": [
                "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd000000000575",
                "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000000420"
            ],
            "tables_not_found": [],
            "vidtorid": {
                "oid:0xd000000000575": "oid:0x80000000d",
                "oid:0x1000000000420": "oid:0x1590000000001"
            }
        },
        "STATE_DB": {
            "keys": [
                "PORT_TABLE|Ethernet64"
            ],
            "tables_not_found": []
        }
    },
    <Truncated>
```




#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

