### PR TITLE
[debug dump] Missing Dict Key handled in the MatchOptimizer

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -732,8 +732,15 @@ def _get_sonic_services():
 
 
 def _get_delayed_sonic_services():
-    out = clicommon.run_command("systemctl list-dependencies --plain sonic-delayed.target | sed '1d'", return_cmd=True)
-    return (unit.strip().rstrip('.timer') for unit in out.splitlines())
+    rc1 = clicommon.run_command("systemctl list-dependencies --plain sonic-delayed.target | sed '1d'", return_cmd=True)
+    rc2 = clicommon.run_command("systemctl is-enabled {}".format(rc1.replace("\n", " ")), return_cmd=True)
+    timer = [line.strip() for line in rc1.splitlines()]
+    state = [line.strip() for line in rc2.splitlines()]
+    services = []
+    for unit in timer:
+        if state[timer.index(unit)] == "enabled":
+            services.append(unit.rstrip(".timer"))
+    return services
 
 
 def _reset_failed_services():
@@ -1188,7 +1195,8 @@ def print_dry_run_message(dry_run):
 @click.argument('patch-file-path', type=str, required=True)
 @click.option('-f', '--format', type=click.Choice([e.name for e in ConfigFormat]),
                default=ConfigFormat.CONFIGDB.name,
-               help='format of config of the patch is either ConfigDb(ABNF) or SonicYang')
+               help='format of config of the patch is either ConfigDb(ABNF) or SonicYang',
+               show_default=True)
 @click.option('-d', '--dry-run', is_flag=True, default=False, help='test out the command without affecting config state')
 @click.option('-n', '--ignore-non-yang-tables', is_flag=True, default=False, help='ignore validation for tables without YANG models', hidden=True)
 @click.option('-i', '--ignore-path', multiple=True, help='ignore validation for config specified by given path which is a JsonPointer', hidden=True)
@@ -1221,7 +1229,8 @@ def apply_patch(ctx, patch_file_path, format, dry_run, ignore_non_yang_tables, i
 @click.argument('target-file-path', type=str, required=True)
 @click.option('-f', '--format', type=click.Choice([e.name for e in ConfigFormat]),
                default=ConfigFormat.CONFIGDB.name,
-               help='format of target config is either ConfigDb(ABNF) or SonicYang')
+               help='format of target config is either ConfigDb(ABNF) or SonicYang',
+               show_default=True)
 @click.option('-d', '--dry-run', is_flag=True, default=False, help='test out the command without affecting config state')
 @click.option('-n', '--ignore-non-yang-tables', is_flag=True, default=False, help='ignore validation for tables without YANG models', hidden=True)
 @click.option('-i', '--ignore-path', multiple=True, help='ignore validation for config specified by given path which is a JsonPointer', hidden=True)
@@ -3899,72 +3908,117 @@ def remove(ctx, interface_name, ip_addr):
 #
 # buffer commands and utilities
 #
-def pgmaps_check_legality(ctx, interface_name, input_pg, is_new_pg):
+def buffer_objects_map_check_legality(ctx, db, interface_name, input_map, is_new_id, is_pg):
     """
-    Tool function to check whether input_pg is legal.
+    Tool function to check whether input_map is legal.
     Three checking performed:
-    1. Whether the input_pg is legal: pgs are in range [0-7]
-    2. Whether the input_pg overlaps an existing pg in the port
+    1. Whether the input_map is legal: pgs are in range [0-7]
+    2. Whether the input_map overlaps an existing pg in the port
     """
-    config_db = ctx.obj["config_db"]
+    def _parse_object_id(idsmap):
+        """
+        Tool function to parse the idsmap
+        Args:
+            idsmap: string containing object IDs map, like 3-4 or 7
+        Return:
+            The upper and lower bound. In case the idsmap is illegal, it returns None, None
+        Example:
+            3-4 => 3, 4
+            7   => 7
+            3-  => None, None
+        """
+        try:
+            match = re.search("^([0-9]+)(-[0-9]+)?$", idsmap)
+            lower = int(match.group(1))
+            if match.group(2):
+                upper = int(match.group(2)[1:])
+            else:
+                upper = lower
+        except Exception:
+            lower, upper = None, None
+
+        return lower, upper
+
+    config_db = db.cfgdb
+    object_name = "priority group" if is_pg else "queue"
 
     try:
-        lower = int(input_pg[0])
-        upper = int(input_pg[-1])
+        # Fetch maximum object id from STATE_DB
+        state_db = db.db
+        field_name = 'max_priority_groups' if is_pg else 'max_queues'
 
-        if upper < lower or lower < 0 or upper > 7:
-            ctx.fail("PG {} is not valid.".format(input_pg))
+        _hash = 'BUFFER_MAX_PARAM_TABLE|{}'.format(interface_name)
+        buffer_max_params = state_db.get_all(state_db.STATE_DB, _hash)
+        maximum_id = int(buffer_max_params.get(field_name)) - 1
     except Exception:
-        ctx.fail("PG {} is not valid.".format(input_pg))
+        ctx.fail("Unable to fetch {} from {} in STATE_DB".format(field_name, _hash))
+
+    lower, upper = _parse_object_id(input_map)
+    if not upper or not lower or upper < lower or lower < 0 or upper > maximum_id:
+        ctx.fail("Buffer {} {} is not valid.".format(object_name, input_map))
 
     # Check overlapping.
     # To configure a new PG which is overlapping an existing one is not allowed
     # For example, to add '5-6' while '3-5' existing is illegal
-    existing_pgs = config_db.get_table("BUFFER_PG")
-    if not is_new_pg:
-        if not (interface_name, input_pg) in existing_pgs.keys():
-            ctx.fail("PG {} doesn't exist".format(input_pg))
+    existing_object_maps = config_db.get_table("BUFFER_PG" if is_pg else "BUFFER_QUEUE")
+    if not is_new_id:
+        if not (interface_name, input_map) in existing_object_maps.keys():
+            ctx.fail("Buffer {} {} doesn't exist".format(object_name, input_map))
         return
 
-    for k, v in existing_pgs.items():
-        port, existing_pg = k
+    for k, v in existing_object_maps.items():
+        port, existing_object_map = k
         if port == interface_name:
-            existing_lower = int(existing_pg[0])
-            existing_upper = int(existing_pg[-1])
+            existing_lower, existing_upper = _parse_object_id(existing_object_map)
             if existing_upper < lower or existing_lower > upper:
                 # new and existing pgs disjoint, legal
                 pass
             else:
-                ctx.fail("PG {} overlaps with existing PG {}".format(input_pg, existing_pg))
+                ctx.fail("Buffer {} {} overlaps with existing {} {}".format(object_name, input_map, object_name, existing_object_map))
 
 
-def update_pg(ctx, interface_name, pg_map, override_profile, add = True):
-    config_db = ctx.obj["config_db"]
+def update_buffer_object(db, interface_name, object_map, override_profile, is_pg, add=True):
+    config_db = db.cfgdb
+    ctx = click.get_current_context()
 
     # Check whether port is legal
     ports = config_db.get_entry("PORT", interface_name)
     if not ports:
         ctx.fail("Port {} doesn't exist".format(interface_name))
 
-    # Check whether pg_map is legal
+    buffer_table = "BUFFER_PG" if is_pg else "BUFFER_QUEUE"
+
+    # Check whether object_map is legal
     # Check whether there is other lossless profiles configured on the interface
-    pgmaps_check_legality(ctx, interface_name, pg_map, add)
+    buffer_objects_map_check_legality(ctx, db, interface_name, object_map, add, is_pg)
 
     # All checking passed
     if override_profile:
         profile_dict = config_db.get_entry("BUFFER_PROFILE", override_profile)
         if not profile_dict:
             ctx.fail("Profile {} doesn't exist".format(override_profile))
-        if not 'xoff' in profile_dict.keys() and 'size' in profile_dict.keys():
-            ctx.fail("Profile {} doesn't exist or isn't a lossless profile".format(override_profile))
-        config_db.set_entry("BUFFER_PG", (interface_name, pg_map), {"profile": override_profile})
+        pool_name = profile_dict.get("pool")
+        if not pool_name:
+            ctx.fail("Profile {} is invalid".format(override_profile))
+        pool_dict = config_db.get_entry("BUFFER_POOL", pool_name)
+        pool_dir = pool_dict.get("type")
+        expected_dir = "ingress" if is_pg else "egress"
+        if pool_dir != expected_dir:
+            ctx.fail("Type of pool {} referenced by profile {} is wrong".format(pool_name, override_profile))
+        if is_pg:
+            if not 'xoff' in profile_dict.keys() and 'size' in profile_dict.keys():
+                ctx.fail("Profile {} doesn't exist or isn't a lossless profile".format(override_profile))
+        config_db.set_entry(buffer_table, (interface_name, object_map), {"profile": override_profile})
     else:
-        config_db.set_entry("BUFFER_PG", (interface_name, pg_map), {"profile": "NULL"})
-    adjust_pfc_enable(ctx, interface_name, pg_map, True)
+        config_db.set_entry(buffer_table, (interface_name, object_map), {"profile": "NULL"})
+
+    if is_pg:
+        adjust_pfc_enable(ctx, db, interface_name, object_map, True)
 
 
-def remove_pg_on_port(ctx, interface_name, pg_map):
-    config_db = ctx.obj["config_db"]
+def remove_buffer_object_on_port(db, interface_name, buffer_object_map, is_pg=True):
+    config_db = db.cfgdb
+    ctx = click.get_current_context()
 
     # Check whether port is legal
     ports = config_db.get_entry("PORT", interface_name)
@@ -3972,30 +4026,32 @@ def remove_pg_on_port(ctx, interface_name, pg_map):
         ctx.fail("Port {} doesn't exist".format(interface_name))
 
     # Remvoe all dynamic lossless PGs on the port
-    existing_pgs = config_db.get_table("BUFFER_PG")
+    buffer_table = "BUFFER_PG" if is_pg else "BUFFER_QUEUE"
+    existing_buffer_objects = config_db.get_table(buffer_table)
     removed = False
-    for k, v in existing_pgs.items():
-        port, existing_pg = k
-        if port == interface_name and (not pg_map or pg_map == existing_pg):
-            need_to_remove = False
+    for k, v in existing_buffer_objects.items():
+        port, existing_buffer_object = k
+        if port == interface_name and (not buffer_object_map or buffer_object_map == existing_buffer_object):
             referenced_profile = v.get('profile')
             if referenced_profile and referenced_profile == 'ingress_lossy_profile':
-                if pg_map:
-                    ctx.fail("Lossy PG {} can't be removed".format(pg_map))
+                if buffer_object_map:
+                    ctx.fail("Lossy PG {} can't be removed".format(buffer_object_map))
                 else:
                     continue
-            config_db.set_entry("BUFFER_PG", (interface_name, existing_pg), None)
-            adjust_pfc_enable(ctx, interface_name, pg_map, False)
+            config_db.set_entry(buffer_table, (interface_name, existing_buffer_object), None)
+            if is_pg:
+                adjust_pfc_enable(ctx, db, interface_name, buffer_object_map, False)
             removed = True
     if not removed:
-        if pg_map:
-            ctx.fail("No specified PG {} found on port {}".format(pg_map, interface_name))
+        object_name = "lossless priority group" if is_pg else "queue"
+        if buffer_object_map:
+            ctx.fail("No specified {} {} found on port {}".format(object_name, buffer_object_map, interface_name))
         else:
-            ctx.fail("No lossless PG found on port {}".format(interface_name))
+            ctx.fail("No {} found on port {}".format(object_name, interface_name))
 
 
-def adjust_pfc_enable(ctx, interface_name, pg_map, add):
-    config_db = ctx.obj["config_db"]
+def adjust_pfc_enable(ctx, db, interface_name, pg_map, add):
+    config_db = db.cfgdb
 
     # Fetch the original pfc_enable
     qosmap = config_db.get_entry("PORT_QOS_MAP", interface_name)
@@ -4070,10 +4126,10 @@ def lossless(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('pg_map', metavar='<pg_map>', required=True)
 @click.argument('override_profile', metavar='<override_profile>', required=False)
-@click.pass_context
-def add_pg(ctx, interface_name, pg_map, override_profile):
+@clicommon.pass_db
+def add_pg(db, interface_name, pg_map, override_profile):
     """Set lossless PGs for the interface"""
-    update_pg(ctx, interface_name, pg_map, override_profile)
+    update_buffer_object(db, interface_name, pg_map, override_profile, True)
 
 
 #
@@ -4083,10 +4139,10 @@ def add_pg(ctx, interface_name, pg_map, override_profile):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('pg_map', metavar='<pg_map>', required=True)
 @click.argument('override_profile', metavar='<override_profile>', required=False)
-@click.pass_context
-def set_pg(ctx, interface_name, pg_map, override_profile):
+@clicommon.pass_db
+def set_pg(db, interface_name, pg_map, override_profile):
     """Set lossless PGs for the interface"""
-    update_pg(ctx, interface_name, pg_map, override_profile, False)
+    update_buffer_object(db, interface_name, pg_map, override_profile, True, False)
 
 
 #
@@ -4095,10 +4151,58 @@ def set_pg(ctx, interface_name, pg_map, override_profile):
 @lossless.command('remove')
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('pg_map', metavar='<pg_map', required=False)
-@click.pass_context
-def remove_pg(ctx, interface_name, pg_map):
+@clicommon.pass_db
+def remove_pg(db, interface_name, pg_map):
     """Clear lossless PGs for the interface"""
-    remove_pg_on_port(ctx, interface_name, pg_map)
+    remove_buffer_object_on_port(db, interface_name, pg_map)
+
+
+#
+# 'queue' subgroup ('config interface buffer queue ...')
+#
+@buffer.group(cls=clicommon.AbbreviationGroup)
+@click.pass_context
+def queue(ctx):
+    """Set or clear buffer configuration"""
+    pass
+
+
+#
+# 'add' subcommand
+#
+@queue.command('add')
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('queue_map', metavar='<queue_map>', required=True)
+@click.argument('buffer_profile', metavar='<buffer_profile>', required=True)
+@clicommon.pass_db
+def add_queue(db, interface_name, queue_map, buffer_profile):
+    """Set lossless QUEUEs for the interface"""
+    update_buffer_object(db, interface_name, queue_map, buffer_profile, False)
+
+
+#
+# 'set' subcommand
+#
+@queue.command('set')
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('queue_map', metavar='<queue_map>', required=True)
+@click.argument('buffer_profile', metavar='<buffer_profile>', required=True)
+@clicommon.pass_db
+def set_queue(db, interface_name, queue_map, buffer_profile):
+    """Set lossless QUEUEs for the interface"""
+    update_buffer_object(db, interface_name, queue_map, buffer_profile, False, False)
+
+
+#
+# 'remove' subcommand
+#
+@queue.command('remove')
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('queue_map', metavar='<queue_map>', required=False)
+@clicommon.pass_db
+def remove_queue(db, interface_name, queue_map):
+    """Clear lossless QUEUEs for the interface"""
+    remove_buffer_object_on_port(db, interface_name, queue_map, False)
 
 
 #

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2665,6 +2665,55 @@ This command is used to configure the priority groups on which lossless traffic 
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#dynamic-buffer-management)
 
+**config interface buffer queue**
+
+This command is used to configure the buffer profiles for queues.
+
+- Usage:
+
+  ```
+  config interface buffer queue add <interface_name> <queue_map> <profile>
+  config interface buffer queue set <interface_name> <queue_map> <profile>
+  config interface buffer queue remove <interface_name> <queue_map>
+  ```
+
+  The <queue_map> represents the map of queues. It can be in one of the following two forms:
+
+  - For a range of priorities, the lower bound and upper bound connected by a dash, like `3-4`
+  - For a single priority, the number, like `6`
+
+  The subcommand `add` is designed for adding a buffer profile for a group of queues. The new queue range must be disjoint with all queues with buffer profile configured.
+
+  For example, currently the buffer profile configured on queue 3-4 on port Ethernet4, to configure buffer profile on queue 4-5 will fail because it isn't disjoint with 3-4. To configure it on range 5-6 will succeed.
+
+  The `profile` parameter represents a predefined egress buffer profile to be configured on the queues.
+
+  The subcommand `set` is designed for modifying an existing group of queues.
+
+  The subcommand `remove` is designed for removing buffer profile on an existing group of queues.
+
+- Example:
+
+  To configure buffer profiles for queues on a port:
+
+  ```
+  admin@sonic:~$ sudo config interface buffer queue add Ethernet0 3-4 egress_lossless_profile
+  ```
+
+  To change the profile used for queues on a port:
+
+  ```
+  admin@sonic:~$ sudo config interface buffer queue set Ethernet0 3-4 new-profile
+  ```
+
+  To remove a group of queues from a port:
+
+  ```
+  admin@sonic:~$ sudo config interface buffer queue remove Ethernet0 3-4
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#dynamic-buffer-management)
+
 ### Show commands
 
 **show buffer information**

--- a/dump/match_infra.py
+++ b/dump/match_infra.py
@@ -385,7 +385,7 @@ class MatchRequestOptimizer():
                 for key in keys:
                     new_ret["return_values"][key] = {}
                     for field in fv_requested:
-                        new_ret["return_values"][key][field] = key_fv[key][field]
+                        new_ret["return_values"][key][field] = key_fv[key].get(field, "")
         return new_ret
 
     def __fill_cache(self, ret):

--- a/dump/match_infra.py
+++ b/dump/match_infra.py
@@ -415,7 +415,10 @@ class MatchRequestOptimizer():
 
     def fetch(self, req_orig):
         req = copy.deepcopy(req_orig)
-        key = req.table + ":" + req.key_pattern
+        sep = "|"
+        if req.db:
+            sep = SonicDBConfig.getSeparator(req.db)
+        key = req.table + sep + req.key_pattern
         if key in self.__key_cache:
             verbose_print("Cache Hit for Key: {}".format(key))
             return self.__fetch_from_cache(key, req)

--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -230,7 +230,7 @@ class FlowCounterStats(object):
                     # counter OID is changed.
                     old_values[-1] = values[-1]
                     for i in diff_column_positions:
-                        old_values[i] = 0
+                        old_values[i] = '0'
                         values[i] = ns_diff(values[i], old_values[i])
                     need_update_cache = True
                     continue
@@ -238,13 +238,13 @@ class FlowCounterStats(object):
                 has_negative_diff = False
                 for i in diff_column_positions:
                     # If any diff has negative value, set all counter values to 0 and update cache
-                    if values[i] < old_values[i]:
+                    if int(values[i]) < int(old_values[i]):
                         has_negative_diff = True
                         break
 
                 if has_negative_diff:
                     for i in diff_column_positions:
-                        old_values[i] = 0
+                        old_values[i] = '0'
                         values[i] = ns_diff(values[i], old_values[i])
                     need_update_cache = True
                     continue

--- a/tests/buffer_input/buffer_test_vectors.py
+++ b/tests/buffer_input/buffer_test_vectors.py
@@ -53,6 +53,20 @@ pool           ingress_lossless_pool
 headroom_type  dynamic
 -------------  ---------------------
 
+Profile: egress_lossless_profile
+----------  --------------------
+dynamic_th  0
+pool        egress_lossless_pool
+size        0
+----------  --------------------
+
+Profile: egress_lossy_profile
+----------  -----------------
+dynamic_th  0
+pool        egress_lossy_pool
+size        0
+----------  -----------------
+
 """
 
 show_buffer_information_output="""\

--- a/tests/buffer_test.py
+++ b/tests/buffer_test.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import pytest
+import mock
+from importlib import reload
 from click.testing import CliRunner
 from unittest import TestCase
 from swsscommon.swsscommon import ConfigDBConnector
@@ -269,3 +272,273 @@ class TestBuffer(object):
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
         print("TEARDOWN")
+
+
+class TestInterfaceBuffer(object):
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(cls):
+        print("SETUP")
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        import config.main as config
+        reload(config)
+        yield
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        from .mock_tables import dbconnector
+        dbconnector.dedicated_dbs = {}
+
+    def test_config_int_buffer_pg_lossless_add(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert {'profile': 'NULL'} == db.cfgdb.get_entry('BUFFER_PG', 'Ethernet0|5')
+            assert {'pfc_enable': '3,4,5'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+
+        # Try to add an existing entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group 5 overlaps with existing priority group 5" in result.output
+
+        # Try to add an overlap entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "2-3"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group 2-3 overlaps with existing priority group 3-4" in result.output
+
+        # Try to add an overlap entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "4-5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group 4-5 overlaps with existing priority group 3-4" in result.output
+
+        # Try to add a lossy profile
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "6", "ingress_lossy_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Profile ingress_lossy_profile doesn't exist or isn't a lossless profile" in result.output
+
+        # Try to add a large pg
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "8", "ingress_lossy_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group 8 is not valid" in result.output
+
+        # Try to use a pg map in wrong format
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "3-", "testprofile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group 3- is not valid" in result.output
+
+        # Try to use a pg which is not a number
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "a"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group a is not valid" in result.output
+
+        # Try to use a non-exist profile
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "7", "testprofile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Profile testprofile doesn't exist" in result.output
+
+        # Try to remove all lossless profiles
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            keys = db.cfgdb.get_keys('BUFFER_PG')
+            assert set(keys) == {('Ethernet0', '0'), ('Ethernet0', '3-4'), ('Ethernet0', '5')}
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["remove"],
+                                   ["Ethernet0"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            keys = db.cfgdb.get_keys('BUFFER_PG')
+            assert keys == [('Ethernet0', '0')]
+            assert {'pfc_enable': ''} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+
+    def test_config_int_buffer_pg_lossless_set(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        # Set a non-exist entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["set"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer priority group 5 doesn't exist" in result.output
+
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["set"],
+                                   ["Ethernet0", "3-4", "headroom_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert {'profile': 'headroom_profile'} == db.cfgdb.get_entry('BUFFER_PG', 'Ethernet0|3-4')
+            assert {'pfc_enable': '3,4'} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+
+    def test_config_int_buffer_pg_lossless_remove(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        # Remove non-exist entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["remove"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "No specified lossless priority group 5 found on port Ethernet0" in result.output
+
+        # Remove lossy PG
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["remove"],
+                                   ["Ethernet0", "0"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Lossy PG 0 can't be removed" in result.output
+
+        # Remove existing lossless PG
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            # Remove one lossless PG
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["remove"],
+                                   ["Ethernet0", "3-4"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert [('Ethernet0', '0')] == db.cfgdb.get_keys('BUFFER_PG')
+            assert {'pfc_enable': ''} == db.cfgdb.get_entry('PORT_QOS_MAP', 'Ethernet0')
+
+        # Remove all lossless PGs is tested in the 'add' test case to avoid repeating adding PGs
+
+    def test_config_int_buffer_queue_add(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        # Not providing a profile
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["add"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Missing argument" in result.output
+
+        # Add existing
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["add"],
+                                   ["Ethernet0", "3-4", "egress_lossy_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer queue 3-4 overlaps with existing queue 3-4" in result.output
+
+        # Normal add
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["add"],
+                                   ["Ethernet0", "5", "egress_lossy_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            queue = db.cfgdb.get_entry('BUFFER_QUEUE', 'Ethernet0|5')
+            assert queue == {'profile': 'egress_lossy_profile'}
+
+        # Large queue ID
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["add"],
+                                   ["Ethernet0", "20", "egress_lossy_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Buffer queue 20 is not valid" in result.output
+
+        # Remove all
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            keys = db.cfgdb.get_keys('BUFFER_QUEUE')
+            assert set(keys) == {('Ethernet0', '3-4'), ('Ethernet0', '5')}
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["remove"],
+                                   ["Ethernet0"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert [] == db.cfgdb.get_keys('BUFFER_QUEUE')
+
+    def test_config_int_buffer_queue_set(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        # Remove non-exist entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["set"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Missing argument" in result.output
+
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["set"],
+                                   ["Ethernet0", "3-4", "headroom_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "Type of pool ingress_lossless_pool referenced by profile headroom_profile is wrong" in result.output
+
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["set"],
+                                   ["Ethernet0", "3-4", "egress_lossy_profile"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            queue = db.cfgdb.get_entry('BUFFER_QUEUE', 'Ethernet0|3-4')
+            assert queue == {'profile': 'egress_lossy_profile'}
+
+    def test_config_int_buffer_queue_remove(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        # Remove non-exist entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["remove"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code
+            assert "No specified queue 5 found on port Ethernet0" in result.output
+
+        # Remove existing queue
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["queue"].commands["remove"],
+                                   ["Ethernet0", "3-4"], obj=db)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+            assert [] == db.cfgdb.get_keys('BUFFER_QUEUE')
+
+        # Removing all queues is tested in "add" test case to avoid repeating adding queues.

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -84,6 +84,8 @@ def mock_run_command_side_effect(*args, **kwargs):
             return 'snmp.timer'
         elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
             return 'swss'
+        elif command == "systemctl is-enabled snmp.timer":
+            return 'enabled'
         else:
             return ''
 
@@ -164,7 +166,7 @@ class TestLoadMinigraph(object):
             mock_run_command.assert_any_call('systemctl reset-failed swss')
             # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
             mock_run_command.assert_any_call('systemctl reset-failed snmp')
-            assert mock_run_command.call_count == 10
+            assert mock_run_command.call_count == 11
 
     def test_load_minigraph_with_port_config_bad_format(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(

--- a/tests/flow_counter_stats_test.py
+++ b/tests/flow_counter_stats_test.py
@@ -132,25 +132,25 @@ class TestTrapStat:
         stats._collect = mock.MagicMock()
         old_data = {
             '': {
-                'bgp': [100, 200, 50.0, 1],
-                'bgpv6': [100, 200, 50.0, 2],
-                'lldp': [100, 200, 50.0, 3],
+                'bgp': ['100', '200', '50.0', '1'],
+                'bgpv6': ['100', '200', '50.0', '2'],
+                'lldp': ['100', '200', '50.0', '3'],
             }
         }
         stats._save(old_data)
         stats.data = {
             '': {
-                'bgp': [100, 200, 50.0, 4],
-                'bgpv6': [100, 100, 50.0, 2],
-                'lldp': [200, 300, 50.0, 3],
+                'bgp': ['100', '200', '50.0', '4'],
+                'bgpv6': ['100', '100', '50.0', '2'],
+                'lldp': ['200', '300', '50.0', '3'],
             }
         }
 
         stats._collect_and_diff()
         cached_data = stats._load()
-        assert cached_data['']['bgp'] == [0, 0, 50.0, 4]
-        assert cached_data['']['bgpv6'] == [0, 0, 50.0, 2]
-        assert cached_data['']['lldp'] == [100, 200, 50.0, 3]
+        assert cached_data['']['bgp'] == ['0', '0', '50.0', '4']
+        assert cached_data['']['bgpv6'] == ['0', '0', '50.0', '2']
+        assert cached_data['']['lldp'] == ['100', '200', '50.0', '3']
 
 
 class TestTrapStatsMultiAsic:

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1767,11 +1767,24 @@
         "pool": "ingress_lossless_pool",
         "headroom_type": "dynamic"
     },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "0",
+        "pool": "egress_lossy_pool",
+        "size": "0"
+    },
     "BUFFER_PG|Ethernet0|3-4": {
         "profile": "NULL"
     },
     "BUFFER_PG|Ethernet0|0": {
         "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet0|3-4": {
+        "profile": "egress_lossless_profile"
     },
     "PORT_QOS_MAP|Ethernet0": {
         "pfc_enable": "3,4"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -626,6 +626,10 @@
     "BUFFER_MAX_PARAM_TABLE|global": {
         "mmu_size": "13945824"
     },
+    "BUFFER_MAX_PARAM_TABLE|Ethernet0": {
+        "max_queues": "20",
+        "max_priority_groups": "8"
+    },
     "CHASSIS_MIDPLANE_TABLE|SUPERVISOR0": {
         "ip_address": "192.168.1.100",
         "access": "True"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did

1) The hardcoded delimiter used in the match_optimizer was updated to dynamically assigned based on the db name provided

2) Sometimes, the kv-pairs received from match engine may not contain the necessary fields requested and in those cases MatchEngine Optimizer is throwing a KeyError Exception on the missing field. Added Unit tests to cover the scenario

```
Traceback (most recent call last):
  File "/usr/local/bin/dump", line 8, in <module>
    sys.exit(dump())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/dump/main.py", line 85, in state
    collected_info[arg] = obj.execute(params)
  File "/usr/local/lib/python3.9/dist-packages/dump/plugins/route.py", line 82, in execute
    self.init_asic_nh()
  File "/usr/local/lib/python3.9/dist-packages/dump/plugins/route.py", line 142, in init_asic_nh
    nh_ex.collect()
  File "/usr/local/lib/python3.9/dist-packages/dump/plugins/route.py", line 211, in collect
    rif_oid = self.init_asic_next_hop_info(self.rt.nh_id)
  File "/usr/local/lib/python3.9/dist-packages/dump/plugins/route.py", line 191, in init_asic_next_hop_info
    ret = self.rt.nhgrp_match_engine.fetch(req)
  File "/usr/local/lib/python3.9/dist-packages/dump/match_infra.py", line 430, in fetch
    return self.__mutate_response(ret, fv_requested, ret_just_keys)
  File "/usr/local/lib/python3.9/dist-packages/dump/match_infra.py", line 389, in __mutate_response
    new_ret["return_values"][key][field] = key_fv[key][field]
KeyError: 'SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID'
```

#### How I did it

Handled the no-field present case gracefully

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

