### PR TITLE
[simx] [techsupport] Avoid running show_platform_info for simx

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -705,11 +705,14 @@ save_saidump() {
 ###############################################################################
 save_platform_info() {
     trap 'handle_error $? $LINENO' ERR
-    save_cmd "show platform syseeprom" "syseeprom"
-    save_cmd "show platform psustatus" "psustatus"
-    save_cmd "show platform ssdhealth" "ssdhealth"
-    save_cmd "show platform temperature" "temperature"
-    save_cmd "show platform fan" "fan"
+    PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
+    if [[ ! $PLATFORM =~ .*(mlnx|nvidia).*simx.* ]]; then
+        save_cmd "show platform syseeprom" "syseeprom"
+        save_cmd "show platform psustatus" "psustatus"
+        save_cmd "show platform ssdhealth" "ssdhealth"
+        save_cmd "show platform temperature" "temperature"
+        save_cmd "show platform fan" "fan" 
+    fi
 }
 
 ###############################################################################


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

show techsupport on simx devices is generating errors when running "show_platform_info".

Added a check to not run show_platform_info for simx devices. 

```
root@sonic-simx-134:/home/admin# sudo generate_dump -s "-60 seconds"
Traceback (most recent call last):
  File "/usr/local/bin/ssdutil", line 8, in <module>
    sys.exit(ssdutil())
  File "/usr/local/lib/python3.9/dist-packages/ssdutil/main.py", line 68, in ssdutil
    ssd = import_ssd_api(args.device)
  File "/usr/local/lib/python3.9/dist-packages/ssdutil/main.py", line 47, in import_ssd_api
    return SsdUtil(diskdev)
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_ssd/ssd_generic.py", line 48, in __init__
    self.parse_generic_ssd_info()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_ssd/ssd_generic.py", line 84, in parse_generic_ssd_info
    self.temperature = self._parse_re('Temperature_Celsius\s*(.+?)\n', self.ssd_info).split()[-6]
IndexError: list index out of range
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

