### PR TITLE
Added a lock to avoid running techsupport in paralell

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -42,18 +42,41 @@ SAVE_STDERR=true
 RETURN_CODE=0
 DEBUG_DUMP=false
 
+EXT_SUCCESS=0; ETMP[0]="EXT_SUCCESS"
+EXT_GENERAL=1; ETMP[1]="EXT_GENERAL"
+EXT_LOCKFAIL=2; ETMP[2]="EXT_LOCKFAIL"
+EXT_RECVSIG=3; ETMP[3]="EXT_RECVSIG"
+
+# lock dirs/files
+LOCKDIR="/tmp/techsupport-lock"
+PIDFILE="${LOCKDIR}/PID"
+
+# Remove lock directory and restart
+rm_lock_and_restart()
+{
+    $RM $V -rf ${LOCKDIR}
+    echo "[generate_dump] Restarting"
+    exec "$0" "$@"
+}
+
+handle_exit()
+{
+    ECODE=$?
+    echo "Removing Lock. Exit: ${ETMP[ECODE]}($ECODE)" >&2
+    $RM $V -rf ${LOCKDIR}
+}
+
 handle_signal()
 {
     echo "Generate Dump received interrupt" >&2
     $RM $V -rf $TARDIR
-    exit 1
+    exit $EXT_RECVSIG
 }
-trap 'handle_signal' SIGINT
 
 handle_error() {
     if [ "$1" != "0" ]; then
         echo "ERR: RC:-$1 observed on line $2" >&2
-        RETURN_CODE=1
+        RETURN_CODE=$EXT_GENERAL
     fi
 }
 
@@ -1141,11 +1164,6 @@ main() {
     trap 'handle_error $? $LINENO' ERR
     local start_t=0
     local end_t=0
-    if [ `whoami` != root ] && ! $NOOP;
-    then
-        echo "$0: must be run as root (or in sudo)" >&2
-        exit 10
-    fi
     NUM_ASICS=$(get_asic_count)
     ${CMD_PREFIX}renice +5 -p $$ >> /dev/null
     ${CMD_PREFIX}ionice -c 2 -n 5 -p $$ >> /dev/null
@@ -1470,7 +1488,7 @@ while getopts ":xnvhzas:t:r:d" opt; do
             ;;
         h)
             usage
-            exit 0
+            exit $EXT_SUCCESS
             ;;
         v)
             # echo commands about to be run to stderr
@@ -1511,9 +1529,48 @@ while getopts ":xnvhzas:t:r:d" opt; do
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2
-            exit 1
+            exit $EXT_GENERAL
             ;;
     esac
 done
 
-main
+# Check permissions before proceeding further
+if [ `whoami` != root ] && ! $NOOP;
+then
+    echo "$0: must be run as root (or in sudo)" >&2
+    exit 10
+fi
+
+##
+## Attempt Locking
+##
+
+if mkdir "${LOCKDIR}" &>/dev/null; then
+    trap 'handle_exit' EXIT
+    echo "$$" > "${PIDFILE}"
+    # This handler will exit the script upon receiving these interrupts
+    # Trap configured on EXIT will be triggered by the exit from handle_signal function
+    trap 'handle_signal' SIGINT SIGHUP SIGQUIT SIGTERM
+    echo "Lock Succesfully Accquired and Installed signal handlers"
+    main
+else
+    # lock failed, check if the other PID is alive
+    PID_PROG="$(cat "${PIDFILE}")"
+
+    if [ $? != 0 ]; then
+        # Another instance is probably about to remove the lock or PIDfile doesn't exist
+        # Wait for a few secs and restart
+        sleep "$(( $RANDOM % 2 + 1)).$(( $RANDOM % 999 ))"
+        rm_lock_and_restart
+    fi
+
+    if ! kill -0 $PID_PROG &>/dev/null; then
+        # Lock is stale
+        echo "Removing stale lock of nonexistant PID ${PID_PROG}"
+        rm_lock_and_restart
+    else
+        # Lock is valid and the other instance is active. Exit Now
+        echo "Accquiring lock failed, PID ${PID_PROG} is active" >&2
+        exit $ERR_LOCKFAIL
+    fi
+fi

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1552,6 +1552,7 @@ if mkdir "${LOCKDIR}" &>/dev/null; then
     # Trap configured on EXIT will be triggered by the exit from handle_signal function
     trap 'handle_signal' SIGINT SIGHUP SIGQUIT SIGTERM
     echo "Lock Succesfully Accquired and Installed signal handlers"
+    # Proceed with the actual code
     main
 else
     # lock failed, check if the other PID is alive
@@ -1571,6 +1572,6 @@ else
     else
         # Lock is valid and the other instance is active. Exit Now
         echo "Accquiring lock failed, PID ${PID_PROG} is active" >&2
-        exit $ERR_LOCKFAIL
+        exit $EXT_LOCKFAIL
     fi
 fi


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added logic to generate_dump script to avoid paralell execution of techsupport.
If a second instance of techsupport starts when one is already running, the second one exits with an appropriate error code

#### Why  I did it

1) Running multiple dumps in paralell has no real use case
2) High CPU load
3) saisdkdump is not designed to run in paralell. When run, these sort of logs are seen indicating failure.
```
'Jan 21 16:27:19.657752 r-tigris-13 ERR syncd#SDK: [SAI_INTERFACE_QUERY_ETH.ERR] mlnx_sai_interfacequery_eth.c[491]- sai_dbg_run_mlxtrace: Failed running "mlxtrace_ext -d /dev/mst/mt53100_pci_cr0 -c /etc/mft/fwtrace_cfg/mlxtrace_spectrum2_itrace.cfg.ext -m MEM -a OB_GW -n -o /tmp/saisdkdump/mt53100_pci_cr0_mlxtrace.trc >/dev/null 2>&1".\n', 
'Jan 21 16:27:19.657752 r-tigris-13 ERR syncd#SDK: [SAI_INTERFACE_QUERY_ETH.ERR] mlnx_sai_interfacequery_eth.c[450]- sai_dbg_do_dump: Failed to run mlxtrace\n', 
'Jan 21 16:27:19.657940 r-tigris-13 ERR syncd#SDK: [DBG.ERR] dbg_generate_dump failed (No such file or directory) - failed to open meta file (/tmp/saisdkdump/sdkdump_ext_meta_001-21_01_2022-16_27_19-657793ryfvpppad.tmp).\n', 
'Jan 21 16:27:19.657940 r-tigris-13 ERR syncd#SDK: [DBG.ERR] Cr space dump failed#012 \n', 
'Jan 21 16:27:19.657940 r-tigris-13 ERR syncd#SDK: [DBG.ERR] dump generation failed\n', 
'Jan 21 16:27:19.658150 r-tigris-13 ERR syncd#SDK: [DBG.ERR] dbg_generate_dump failed (No such file or directory) - failed to open meta file (/tmp/saisdkdump/sdkdump_ext_meta_001-21_01_2022-16_27_19-658036fcbohbntn.tmp).\n', 
'Jan 21 16:27:19.658150 r-tigris-13 ERR syncd#SDK: [DBG.ERR] Cr space dump failed#012 \n', 
'Jan 21 16:27:19.658150 r-tigris-13 ERR syncd#SDK: [DBG.ERR] dump generation failed\n', 
'Jan 21 16:27:19.658309 r-tigris-13 ERR syncd#SDK: [DBG.ERR] dbg_generate_dump failed (No such file or directory) - failed to open meta file (/tmp/saisdkdump/sdkdump_ext_meta_001-21_01_2022-16_27_19-658209kqecbynts.tmp).\n', 
'Jan 21 16:27:19.658325 r-tigris-13 ERR syncd#SDK: [DBG.ERR] Cr space dump failed#012 \n', 
'Jan 21 16:27:19.658325 r-tigris-13 ERR syncd#SDK: [DBG.ERR] dump generation failed\n', 
'Jan 21 16:33:13.182859 r-tigris-13 ERR kernel: [24781.164251] mlxsw_minimal 2-0048: Reg cmd access status failed (status=1(device is busy))\n', 
'Jan 21 16:33:13.182929 r-tigris-13 ERR kernel: [24781.262347] mlxsw_minimal 2-0048: Reg cmd access failed (reg_id=9014(mcia),type=query)\n'
```

#### How to verify it

**Scenario 1: Try paralell execution of techsupport**
```
root@sonic:/home/admin# show techsupport --silent
Techsupport is running with silent option. This command might take a long time.
Lock Succesfully Accquired and Installed signal handlers
<ts_stdout>
Removing Lock. Exit: EXT_SUCCESS(0)
root@sonic:/home/admin# echo $?
0

In paralell
root@sonic:/home/admin# show techsupport --silent
Techsupport is running with silent option. This command might take a long time.
Accquiring lock failed, PID 330976 is active
root@sonic:/home/admin# echo $?
2 
```

**Scenario 2: Try executing techsupport with a stale lock file**
```
<Create a stale lock file>
root@sonic:/home/admin# cat /tmp/techsupport-lock/PID
330976

root@sonic:/home/admin# show techsupport --silent
Techsupport is running with silent option. This command might take a long time.
Removing stale lock of nonexistant PID 330976
[generate_dump] Restarting
Lock Succesfully Accquired and Installed signal handlers
<ts_stdout>
Removing Lock. Exit: EXT_SUCCESS(0)
root@sonic:/home/admin# echo $?
0

While the above process is running 
root@sonic:/home/admin# cat /tmp/techsupport-lock/PID
339423
```

**Scenario 3: Try executing techsupport with a stale lock directory**
```
root@r-lionfish-16:/home/admin# mkdir /tmp/techsupport-lock/
root@r-lionfish-16:/home/admin#

Techsupport is running with silent option. This command might take a long time.
cat: /tmp/techsupport-lock/PID: No such file or directory
[generate_dump] Restarting
Lock Succesfully Accquired and Installed signal handlers
<ts_stdout>
Removing Lock. Exit: EXT_SUCCESS(0)
```

**Scenario 4: Kill the techsupport process with any of the termination signals:**
```
root@sonic:/home/admin# show techsupport --silent
Techsupport is running with silent option. This command might take a long time.
Lock Succesfully Accquired and Installed signal handlers
Generate Dump received interrupt
Removing Lock. Exit: EXT_RECVSIG(3)
root@sonic:/home/admin# echo $?
3

In Paralell
root@sonic:/home/admin# cat /tmp/techsupport-lock/PID
356319
#### Kill the techsupport process
root@sonic:/home/admin# kill -1 356319 
#### The lock file is also deleted
root@sonic:/home/admin# cat /tmp/techsupport-lock/PID
cat: /tmp/techsupport-lock/PID: No such file or directory
```

**Scenario 5: Check compatibility with auto-techsupport**
```
# Generate a core dump
root@sonic:/home/admin# docker exec teamd ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          21  0.0  0.0  88208  7116 pts/0    Sl   Jan31   0:23 /usr/bin/tlm_teamd

root@sonic:/home/admin# docker exec teamd kill -6 21

root@sonic:/home/admin# ps -aux | grep "coredump_gen"
root      364799  0.5  0.2  30148 17184 ?        S    02:07   0:00 python3 /usr/local/bin/coredump_gen_handler.py tlm_teamd.1643681220.21.core.gz teamd

root@sonic:/home/admin# ls /var/dump/
sonic_dump_sonic_20220201_020701  sonic_dump_sonic_20220201_020701.tar

In paralell:
root@sonic:/home/admin# show techsupport --silent
Techsupport is running with silent option. This command might take a long time.
Accquiring lock failed, PID 364824 is active
root@sonic:/home/admin# echo $?
2
```






#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

