### PR TITLE
[techsupport] Handle Minor Issues because of TS Locking

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1364,8 +1364,6 @@ main() {
 
     # Invoke the TechSupport Cleanup Hook
     setsid python3 /usr/local/bin/techsupport_cleanup.py ${TARFILE} &> /tmp/techsupport_cleanup.log &
-
-    echo ${TARFILE}
     
     if ! $SAVE_STDERR
     then

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -63,6 +63,10 @@ handle_exit()
     ECODE=$?
     echo "Removing lock. Exit: $ECODE" >&2
     $RM $V -rf ${LOCKDIR}
+    # Echo the filename as the last statement if the generation suceeds
+    if [[ -f $TARFILE && ($ECODE == $EXT_SUCCESS || $ECODE == $RETURN_CODE) ]]; then
+        echo $TARFILE
+    fi
 }
 
 handle_signal()
@@ -1494,7 +1498,6 @@ while getopts ":xnvhzas:t:r:d" opt; do
             ;;
         v)
             # echo commands about to be run to stderr
-            set -v
             V="-v"
             ;;
         n)
@@ -1547,7 +1550,7 @@ fi
 ## Attempt Locking
 ##
 
-if mkdir "${LOCKDIR}" &>/dev/null; then
+if $MKDIR "${LOCKDIR}" &>/dev/null; then
     trap 'handle_exit' EXIT
     echo "$$" > "${PIDFILE}"
     # This handler will exit the script upon receiving these interrupts
@@ -1555,6 +1558,9 @@ if mkdir "${LOCKDIR}" &>/dev/null; then
     trap 'handle_signal' SIGINT SIGHUP SIGQUIT SIGTERM
     echo "Lock succesfully accquired and installed signal handlers"
     # Proceed with the actual code
+    if [[ ! -z "${V}" ]]; then
+        set -v
+    fi
     main
 else
     # lock failed, check if the other PID is alive


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1) Print the last statement as the techsupport dump name, as some automation processes might depend of parsing the last line to infer the dump path.

```
Previously:
handle_exit
Removing lock. Exit: 0
removed '/tmp/techsupport-lock/PID'
removed directory '/tmp/techsupport-lock'

Updated:
handle_exit
Removing lock. Exit: 0
removed '/tmp/techsupport-lock/PID'
removed directory '/tmp/techsupport-lock'
/var/dump/sonic_dump_r-bulldog-03_20220324_195553.tar.gz
```


2) Don't acquire the lock when running in NOOP mode

3) Set the set -v option just before running main so that it won't print the downstream text/code to stdout

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

