### PR TITLE
Made changes to only allow a valid IPv4 or Ipv6 string

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -1,4 +1,5 @@
 import click
+import ipaddress
 import utilities_common.cli as clicommon
 
 from time import sleep
@@ -198,7 +199,9 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
 
     ctx = click.get_current_context()
 
-    if not clicommon.is_ipaddress(dhcp_relay_destination_ip):
+    try:
+        ipaddress.ip_address(dhcp_relay_destination_ip)
+    except Exception:
         ctx.fail('{} is invalid IP address'.format(dhcp_relay_destination_ip))
 
     vlan_name = 'Vlan{}'.format(vid)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -536,6 +536,19 @@ class TestVlan(object):
             assert "Error: 192.0.0.1000 is invalid IP address" in result.output
             assert mock_run_command.call_count == 0
 
+    def test_config_vlan_add_dhcp_relay_with_invalid_ip_2(self):
+        runner = CliRunner()
+
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["vlan"].commands["dhcp_relay"].commands["add"],
+                                   ["1000", "110000"])
+            print(result.exit_code)
+            print(result.output)
+            # traceback.print_tb(result.exc_info[2])
+            assert result.exit_code != 0
+            assert "Error: 110000 is invalid IP address" in result.output
+            assert mock_run_command.call_count == 0
+
     def test_config_vlan_add_dhcp_relay_with_exist_ip(self):
         runner = CliRunner()
 


### PR DESCRIPTION
Signed-off-by: Vivek Reddy <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Currently, 
```
root@qa-eth-vt04-3-2700a0:/home/admin# config vlan dhcp_relay add 125 11
Added DHCP relay destination address 11 to Vlan125
Restarting DHCP relay service...
root@qa-eth-vt04-3-2700a0:/home/admin# config vlan dhcp_relay add 125 1100000
Added DHCP relay destination address 1100000 to Vlan125
Restarting DHCP relay service...
root@qa-eth-vt04-3-2700a0:/home/admin# show vla bri
+-----------+--------------+-----------+----------------+-----------------------+-------------+
|   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+===========+==============+===========+================+=======================+=============+
|       125 | 2000::1:1/64 | Ethernet4 | tagged         | 500                   | disabled    |
|           |              |           |                | 11                    |             |
|           |              |           |                | 1100000               |             |
|           |              |           |                | 2000:1::2             |             |
+-----------+--------------+-----------+----------------+-----------------------+-------------+
```

Made changes to take in a valid IP string.

After the change:
```
root@qa-eth-vt02-7-3420:/home/admin# config vlan dhcp_relay add 125 1100000
Error: 1100000 is invalid IP address
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

